### PR TITLE
cpt creation command fixed

### DIFF
--- a/web/app/mu-plugins/juniper-commands.php
+++ b/web/app/mu-plugins/juniper-commands.php
@@ -65,26 +65,28 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WP_CLI' ) ) {
 
 				$this->validate_name( $og_name );
 
-				extract( $this->get_needed_names( $og_name ) );
+				extract( $this->get_needed_names( $og_name ) ); // phpcs:ignore
 
-				if ( file_exists( $this->mu_plugins . "/../themes/juniper-theme/inc/Cpt/$slug_name.php" ) ) {
+				$class_name = ucfirst( $slug_name );
+
+				if ( file_exists( $this->mu_plugins . "/../themes/juniper-theme/inc/Cpt/$class_name.php" ) ) {
 					WP_CLI::error( 'Custom post type already exists' );
 				}
 
 				$replace_array = array(
-					array( 'replace_cpt_slug', $slug_name ),
+					array( 'replace_cpt_slug', $class_name ),
 					array( 'replace_cpt_name', $og_name ),
 					array( 'replace_rewrite_name', $rewrite_name ),
 				);
 
-				$file_contents = file_get_contents( $this->mu_plugins . '/../../../dev/cpt.txt' );
+				$file_contents = file_get_contents( $this->mu_plugins . '/../../../dev/cpt.txt' ); // phpcs:ignore
 				foreach ( $replace_array as $search_replace ) {
 					$file_contents = str_replace( $search_replace[0], $search_replace[1], $file_contents );
 				}
 
-				file_put_contents( $this->mu_plugins . "/../themes/juniper-theme/inc/Cpt/$slug_name.php", $file_contents );
+				file_put_contents( $this->mu_plugins . "/../themes/juniper-theme/inc/Cpt/$class_name.php", $file_contents );
 
-				$new_class = "\$juniper_$slug_name = new \Juniper\cpt\\$slug_name();" . PHP_EOL;
+				$new_class = "\$juniper_$slug_name = new \Juniper\Cpt\\$class_name();" . PHP_EOL;
 				file_put_contents( $this->mu_plugins . '/../themes/juniper-theme/inc/include.php', $new_class, FILE_APPEND );
 
 				shell_exec( 'phpcbf --standard=WordPress-Extra ' . $this->mu_plugins . "/../themes/juniper-theme/inc/Cpt/$slug_name.php" );

--- a/web/app/themes/juniper-theme/functions.php
+++ b/web/app/themes/juniper-theme/functions.php
@@ -23,9 +23,9 @@ if ( file_exists( $composer_autoload ) ) {
 require_once 'inc/include.php';
 
 function juniper_theme_enqueue() {
-	$refresh_cache_time = time();
+	$refresh_cache_time     = time();
 	$template_directory_uri = get_template_directory_uri();
-	
+
 	wp_enqueue_style( 'app-css', $template_directory_uri . '/dist/src/css/_app.css', array(), $refresh_cache_time );
 	wp_enqueue_script( 'app-js', $template_directory_uri . '/dist/src/js/_app.js', array(), $refresh_cache_time, true );
 }


### PR DESCRIPTION
Fix for `wp add cpt --name="Product"`

Previously, the script created a file with a lowercase capital letter (`product.php`), as well as created CPT's class name  (`class product {`). Lastly, the creation of the new instance of the CPT within the `inc/include.php` used wrong namespace (`$juniper_product  = new \Juniper\cpt\product();`). As a result, there was a fatal error when on < PHP8.1:

Fatal error: Uncaught Error: Class "Juniper\cpt\product" not found in web/app/themes/juniper-theme/inc/include.php:8