### PR TITLE
add ACF options caching to Timber context

### DIFF
--- a/web/app/themes/juniper-theme/class-startersite.php
+++ b/web/app/themes/juniper-theme/class-startersite.php
@@ -19,7 +19,8 @@ class StarterSite extends Timber\Site {
 	 * @param string $context context['this'] Being the Twig's {{ this }}.
 	 */
 	public function add_to_context( $context ) {
-		$context['site'] = $this;
+		$context['site']    = $this;
+		$context['options'] = juniper_get_cached_options();
 		return $context;
 	}
 

--- a/web/app/themes/juniper-theme/inc/include.php
+++ b/web/app/themes/juniper-theme/inc/include.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once 'optimization.php';
 require_once 'gutenberg-styles.php';
 require_once 'pattern-categories.php';
 

--- a/web/app/themes/juniper-theme/inc/optimization.php
+++ b/web/app/themes/juniper-theme/inc/optimization.php
@@ -17,14 +17,16 @@ function juniper_get_cached_options( bool $use_cache = false ): array {
 	$use_cache = apply_filters( 'juniper_use_options_cache', $use_cache );
 
 	if ( ! $use_cache ) {
-		return get_fields( 'options' ) ?: array();
+		$fields = get_fields( 'options' );
+		return $fields ? $fields : array();
 	}
 
 	$cache_key = 'juniper_acf_options';
 	$options   = get_transient( $cache_key );
 
 	if ( false === $options ) {
-		$options = get_fields( 'options' ) ?: array();
+		$options = get_fields( 'options' );
+		$options = $options ? $options : array();
 		set_transient( $cache_key, $options, WEEK_IN_SECONDS );
 	}
 

--- a/web/app/themes/juniper-theme/inc/optimization.php
+++ b/web/app/themes/juniper-theme/inc/optimization.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Get cached ACF options page fields
+ *
+ * This function caches the ACF options to avoid multiple database queries
+ * on each page load. Cache is invalidated when ACF options are saved.
+ *
+ * @param bool $use_cache Optional. Whether to use cache. Default false.
+ * @return array The cached options or empty array if ACF is not available
+ */
+function juniper_get_cached_options( bool $use_cache = false ): array {
+	if ( ! class_exists( 'ACF' ) ) {
+		return array();
+	}
+
+	$use_cache = apply_filters( 'juniper_use_options_cache', $use_cache );
+
+	if ( ! $use_cache ) {
+		return get_fields( 'options' ) ?: array();
+	}
+
+	$cache_key = 'juniper_acf_options';
+	$options   = get_transient( $cache_key );
+
+	if ( false === $options ) {
+		$options = get_fields( 'options' ) ?: array();
+		set_transient( $cache_key, $options, WEEK_IN_SECONDS );
+	}
+
+	return $options;
+}
+
+/**
+ * Clear ACF options cache when options page is saved
+ */
+function juniper_clear_options_cache(): void {
+	delete_transient( 'juniper_acf_options' );
+}
+
+add_action( 'acf/options_page/save', 'juniper_clear_options_cache', 20 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site templates now receive centralized site options for consistent rendering.

* **Performance**
  * Implemented caching for site options to reduce load times.
  * Cache is automatically cleared when site options are updated to keep content fresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->